### PR TITLE
Count maximum warning level properly

### DIFF
--- a/js/swv.js
+++ b/js/swv.js
@@ -548,7 +548,7 @@ angular.module("swv", ["ui.directives", "ui.filters"])
             });
 
             const timeWarn = moment.utc().subtract('10', 'days').format('YYYY-MM-DDTHH:mm:ss') + "Z";
-            var maxWarnCount = Number(SEdit.config.warn['countWarn']) - 1;
+            var maxWarnCount = Number(SEdit.config.warn['countWarn']);
             var warnMonth = moment.utc().format('MMMM');
 
             if (typeof SEdit.config.warn['months'] !== 'undefined')
@@ -569,7 +569,7 @@ angular.module("swv", ["ui.directives", "ui.filters"])
                     if (warnCount === -1 || (warnCount !== -1 && warnCount < maxWarnCount)) {
                         if (warnCount === -1) warnCount = 0;
                         warnCount = warnCount + 1;
-                        if (max === true && (Object.keys(templates).length >= warnCount && Object.keys(templates).length <= maxWarnCount + 1)) warnCount = Object.keys(templates).length; // if need max level
+                        if (max === true && (Object.keys(templates).length >= warnCount && Object.keys(templates).length <= maxWarnCount)) warnCount = Object.keys(templates).length; // if need max level
                         if (templates[warnCount] === "undefined") throw useLang["warn-perform-fail"].replace("$1", SEdit.title);
                         await sendWarning(SEdit.server_url, SEdit.script_path, SEdit.wiki, SEdit.new, SEdit.old, SEdit.title, SEdit.user, warnCount, templates, warnMonth, SEdit.config.warn['summaryWarn'], SEdit.config.warn['sectionWarn'], (description.withoutSection || false));
                         $scope.sessionActions.warn++;
@@ -579,7 +579,7 @@ angular.module("swv", ["ui.directives", "ui.filters"])
                             content: useLang["warn-performed-content"].replace("$1", `[[${SEdit.user}||${SEdit.server_url}/wiki/Special:Contributions/${SEdit.user}]]`).replace("$2", `[[${SEdit.title}||${SEdit.server_url}${SEdit.script_path}/index.php?title=${SEdit.title}&action=history]]`),
                             removable: true
                         });
-                    } else if (warnCount === maxWarnCount) $scope.doReport(SEdit);
+                    } else if (warnCount >= maxWarnCount) $scope.doReport(SEdit);
                 }).catch(err => createNotify({
                 img: '/img/warning-filled.svg',
                 title: useLang["warn-fail-title"],

--- a/js/swv.js
+++ b/js/swv.js
@@ -1759,9 +1759,9 @@ function checkIfAlreadyReported(serverUrl, scriptPath, wiki, user, pageReport, t
 
 function getNewFromDiff(diffContent) {
     return diffContent.replace(/<tr>([^]*?)<\/tr>/g, function ($0, $1) {
-        if ($1.search(/<td class="deletedline"/g) === -1 &&
+        if ($1.search(/<td class="deletedline/g) === -1 &&
             $1.search(/<td class="diff-marker">-<\/td>/g) === -1 &&
-            $1.search(/<td class="diff-context"/g) === -1 &&
+            $1.search(/<td class="diff-context/g) === -1 &&
             $1.search(/<ins/g) === -1 &&
             $1.search(/<del/g) === -1)
             return $1;

--- a/js/swv.js
+++ b/js/swv.js
@@ -1759,9 +1759,9 @@ function checkIfAlreadyReported(serverUrl, scriptPath, wiki, user, pageReport, t
 
 function getNewFromDiff(diffContent) {
     return diffContent.replace(/<tr>([^]*?)<\/tr>/g, function ($0, $1) {
-        if ($1.search(/<td class="deletedline">/g) === -1 &&
+        if ($1.search(/<td class="deletedline"/g) === -1 &&
             $1.search(/<td class="diff-marker">-<\/td>/g) === -1 &&
-            $1.search(/<td class="diff-context">/g) === -1 &&
+            $1.search(/<td class="diff-context"/g) === -1 &&
             $1.search(/<ins/g) === -1 &&
             $1.search(/<del/g) === -1)
             return $1;

--- a/js/swv.js
+++ b/js/swv.js
@@ -569,7 +569,7 @@ angular.module("swv", ["ui.directives", "ui.filters"])
                     if (warnCount === -1 || (warnCount !== -1 && warnCount < maxWarnCount)) {
                         if (warnCount === -1) warnCount = 0;
                         warnCount = warnCount + 1;
-                        if (max === true && (Object.keys(templates).length >= warnCount && Object.keys(templates).length <= maxWarnCount)) warnCount = Object.keys(templates).length; // if need max level
+                        if (max === true && Object.keys(templates).length >= warnCount) warnCount = Object.keys(templates).length; // if need max level
                         if (templates[warnCount] === "undefined") throw useLang["warn-perform-fail"].replace("$1", SEdit.title);
                         await sendWarning(SEdit.server_url, SEdit.script_path, SEdit.wiki, SEdit.new, SEdit.old, SEdit.title, SEdit.user, warnCount, templates, warnMonth, SEdit.config.warn['summaryWarn'], SEdit.config.warn['sectionWarn'], (description.withoutSection || false));
                         $scope.sessionActions.warn++;


### PR DESCRIPTION
This fixes https://meta.wikimedia.org/wiki/Special:Permalink/22970127#%5BBUG%5D%3A_Autoreporting_one_before_maximum_warn_count by changing maxWarnCount to simply be equal to countWarn in the config. I have also changed `warncount === maxWarnCount` to `warnCount >= maxWarnCount` to allow reporting behavior to function correctly on wikis that have a separate max-level and immediate max-level warning template.